### PR TITLE
Support redirect with urlopen for before Python 3.11

### DIFF
--- a/labelme_toolkit/_cli/_install_pro.py
+++ b/labelme_toolkit/_cli/_install_pro.py
@@ -1,7 +1,11 @@
 import hashlib
 import subprocess
 import sys
-import urllib.request
+
+if sys.version_info < (3, 11):
+    from .._urllib import urlopen
+else:
+    from urllib.request import urlopen
 from typing import Optional
 
 import click
@@ -45,7 +49,7 @@ def install_pro(
 
     url_path = "https://labelme.io/pro/install"
 
-    with urllib.request.urlopen(f"{url_path}/versions") as response:
+    with urlopen(f"{url_path}/versions") as response:
         data = response.read()
         versions = [version.strip() for version in data.decode("utf-8").splitlines()]
 

--- a/labelme_toolkit/_cli/_install_pro_test.py
+++ b/labelme_toolkit/_cli/_install_pro_test.py
@@ -1,0 +1,5 @@
+import subprocess
+
+
+def test_install_pro_list_versions():
+    subprocess.check_call(["labelmetk", "install-pro", "--list-versions"])

--- a/labelme_toolkit/_urllib.py
+++ b/labelme_toolkit/_urllib.py
@@ -1,0 +1,18 @@
+import contextlib
+import urllib.request
+
+from loguru import logger
+
+
+@contextlib.contextmanager
+def urlopen(url: str, *args, **kwargs):
+    try:
+        with urllib.request.urlopen(url, *args, **kwargs) as response:
+            yield response
+    except urllib.error.HTTPError as e:
+        if "Location" not in e.headers:
+            raise
+        redirected_url = e.headers["Location"]
+        logger.debug("Redirected from {!r} to {!r}", url, redirected_url)
+        with urlopen(redirected_url, *args, **kwargs) as response:
+            yield response


### PR DESCRIPTION
## Why?

urlopen won't redirect in python < 3.11

<img width="1300" alt="image" src="https://github.com/user-attachments/assets/d094c9af-19c5-477e-b1cf-0f1cd5741d63">
